### PR TITLE
fix: 不打印外边框改为按纸面 1mm 内退打印窗口

### DIFF
--- a/src/AutoCAD/PlotterService.cs
+++ b/src/AutoCAD/PlotterService.cs
@@ -321,20 +321,19 @@ public static class PlotterService
         try
         {
             using var tr = db.TransactionManager.StartTransaction();
-            var frameLayerApplied = settings.HideFrameBoundaryWhenPlotting
-                && TemporaryFramePlotLayer.Apply(tr, db, job);
             var layout = FindLayoutForJob(tr, db, job);
             var window = GetPlotWindow(job, plotDocument);
-            using var plot = CreateValidatedPlot(layout, job, window, deviceName, styleSheet);
+            using var plot = CreateValidatedPlot(
+                layout,
+                job,
+                window,
+                deviceName,
+                styleSheet,
+                settings.HideFrameBoundaryWhenPlotting);
 
             PrepareOutputFile(job.OutputPath);
             RunPlot(plot.Info, documentName, job.OutputPath, job.DrawingNumber);
-
-            // 临时移层与绘图必须处于同一事务。绘图引擎结束后故意不提交，让 CAD 原子回滚实体、图层及锁定状态。
-            if (!frameLayerApplied)
-            {
-                tr.Commit();
-            }
+            tr.Commit();
             WaitForPlotIdle();
             ValidatePlotOutput(job.OutputPath);
         }
@@ -349,17 +348,18 @@ public static class PlotterService
         PlotJob job,
         Extents2d window,
         string deviceName,
-        string styleSheet)
+        string styleSheet,
+        bool hideOuterFrame)
     {
         try
         {
-            return CreateValidatedPlotCore(layout, job, window, deviceName, styleSheet);
+            return CreateValidatedPlotCore(layout, job, window, deviceName, styleSheet, hideOuterFrame);
         }
         catch (CachedMediaCatalogException)
         {
             // PC3/PMP 可能在 CAD 会话中被更新；仅当缓存目录失效时清缓存并完整读取一次。
             InvalidateMediaCatalog(deviceName);
-            return CreateValidatedPlotCore(layout, job, window, deviceName, styleSheet);
+            return CreateValidatedPlotCore(layout, job, window, deviceName, styleSheet, hideOuterFrame);
         }
     }
 
@@ -368,7 +368,8 @@ public static class PlotterService
         PlotJob job,
         Extents2d window,
         string deviceName,
-        string styleSheet)
+        string styleSheet,
+        bool hideOuterFrame)
     {
         var validator = PlotSettingsValidator.Current;
         var media = ChooseMedia(validator, layout, deviceName, job, window, out var usedCachedCatalog);
@@ -382,7 +383,16 @@ public static class PlotterService
             try
             {
                 settings.CopyFrom(layout);
-                ConfigurePlotSettings(validator, settings, deviceName, styleSheet, media, rotation, window, job);
+                ConfigurePlotSettings(
+                    validator,
+                    settings,
+                    deviceName,
+                    styleSheet,
+                    media,
+                    rotation,
+                    window,
+                    job,
+                    hideOuterFrame);
 
                 var info = new PlotInfo
                 {
@@ -402,7 +412,7 @@ public static class PlotterService
                 {
                     // AutoCAD 2024 会在 PlotInfo 校验阶段把部分毫米自定义介质重新匹配为英寸介质。
                     // 必须按最终单位重写比例并重新居中，否则毫米分子会被按英寸解释，内容放大 25.4 倍。
-                    ConfigurePlotScale(validator, settings, window, job, deviceName);
+                    ConfigurePlotScale(validator, settings, window, job, deviceName, hideOuterFrame);
                     ResetAndCenterPlot(validator, settings);
                     new PlotInfoValidator
                     {
@@ -447,7 +457,8 @@ public static class PlotterService
         MediaChoice media,
         PlotRotation rotation,
         Extents2d window,
-        PlotJob job)
+        PlotJob job,
+        bool hideOuterFrame)
     {
         try
         {
@@ -478,7 +489,7 @@ public static class PlotterService
         // 必须先写入 DCS 窗口，再切换打印类型；柱状图 299x212mm 自定义纸已做宿主验证。
         validator.SetPlotWindowArea(settings, window);
         validator.SetPlotType(settings, Autodesk.AutoCAD.DatabaseServices.PlotType.Window);
-        ConfigurePlotScale(validator, settings, window, job, deviceName);
+        ConfigurePlotScale(validator, settings, window, job, deviceName, hideOuterFrame);
         validator.SetPlotRotation(settings, rotation);
         // 初次校验前只按最终旋转居中。部分 90° 自定义介质此时不接受显式 SetPlotOrigin(0,0)。
         // 若校验后单位被改成 Inches，再在上面的二次校验分支统一清零原点并重新居中。
@@ -488,6 +499,12 @@ public static class PlotterService
         {
             validator.SetCurrentStyleSheet(settings, styleSheet);
         }
+
+        // 比例和留白已按原窗口写入；内退只替换打印窗口，避免 ScaleToFit 把裁切后的内容重新铺满纸面。
+        if (hideOuterFrame)
+        {
+            TryApplyHiddenFrameWindow(validator, settings, window, job, deviceName);
+        }
     }
 
     private static void ConfigurePlotScale(
@@ -495,11 +512,12 @@ public static class PlotterService
         PlotSettings settings,
         Extents2d window,
         PlotJob job,
-        string deviceName)
+        string deviceName,
+        bool hideOuterFrame = false)
     {
         if (!job.LeavePaperMargin)
         {
-            if (job.UseExactWindowScale)
+            if (job.UseExactWindowScale || hideOuterFrame)
             {
                 SetExactWindowScale(validator, settings, window, deviceName);
                 return;
@@ -565,6 +583,35 @@ public static class PlotterService
         var scale = Math.Min(paperLong / windowLong, paperShort / windowShort);
         validator.SetUseStandardScale(settings, false);
         validator.SetCustomPrintScale(settings, new CustomScale(ToPlotPaperUnitScale(settings, scale), 1d));
+    }
+
+    /// <summary>
+    /// 在比例已按原窗口写入后，把打印窗口四边各内退 1mm 纸面。
+    /// 选纸、旋转和留白仍使用 <paramref name="originalWindow"/>。
+    /// </summary>
+    private static void TryApplyHiddenFrameWindow(
+        PlotSettingsValidator validator,
+        PlotSettings settings,
+        Extents2d originalWindow,
+        PlotJob job,
+        string deviceName)
+    {
+        var paper = GetPlotPaperSizeMm(settings, deviceName);
+        var millimetersPerDrawingUnit = PlotWindowInset.ResolveMillimetersPerDrawingUnit(
+            originalWindow,
+            paper.X,
+            paper.Y,
+            job);
+        if (!PlotWindowInset.TryInsetByPaperMillimeters(
+                originalWindow,
+                millimetersPerDrawingUnit,
+                PlotWindowInset.PaperInsetMm,
+                out var insetWindow))
+        {
+            return;
+        }
+
+        validator.SetPlotWindowArea(settings, insetWindow);
     }
 
     private static double ToPlotPaperUnitScale(PlotSettings settings, double millimetersPerDrawingUnit)
@@ -1301,19 +1348,17 @@ public static class PlotterService
         {
             using var tr = db.TransactionManager.StartTransaction();
             var settings = AppSettingsStore.Load();
-            var frameLayerApplied = settings.HideFrameBoundaryWhenPlotting
-                && TemporaryFramePlotLayer.Apply(tr, db, job);
             var layout = FindLayoutForJob(tr, db, job);
             var window = GetPlotWindow(job, plotDocument);
-            using var plot = CreateValidatedPlot(layout, job, window, deviceName, styleSheet);
+            using var plot = CreateValidatedPlot(
+                layout,
+                job,
+                window,
+                deviceName,
+                styleSheet,
+                settings.HideFrameBoundaryWhenPlotting);
             RunPreview(plot.Info, documentName);
-
-            // 预览必须和正式输出使用同一套外框可打印状态；应用临时移层后不提交事务，
-            // 预览关闭、失败或取消时均由 CAD 原子回滚，避免修改用户图纸。
-            if (!frameLayerApplied)
-            {
-                tr.Commit();
-            }
+            tr.Commit();
             WaitForPlotIdle();
         }
         finally

--- a/src/Common/AppSettingsStore.cs
+++ b/src/Common/AppSettingsStore.cs
@@ -62,8 +62,8 @@ public sealed class AppSettings
     /// </summary>
     public bool RecognizeFourLineRectangleFrames { get; set; }
     /// <summary>
-    /// 正式批量打印时是否临时把已识别的图框外边框移到不打印层。
-    /// 首次使用默认关闭，由用户明确勾选后才隐藏边框；实体和临时图层状态必须在成功、失败或取消后恢复。
+    /// 正式打印时是否把打印内容四边各裁 1mm 纸面，使图框外边框不再输出。
+    /// 首次使用默认关闭；裁切不改纸张、比例和留白，也不修改 DWG。
     /// </summary>
     public bool HideFrameBoundaryWhenPlotting { get; set; } = false;
     public bool AddSequenceWhenPdfExists { get; set; } = false;

--- a/src/Common/Pages/SettingsForm.cs
+++ b/src/Common/Pages/SettingsForm.cs
@@ -213,7 +213,7 @@ public sealed class SettingsForm : Form
         var hideFrameTip = new ToolTip();
         hideFrameTip.SetToolTip(
             _hideFrameBoundaryWhenPlotting,
-            "勾选后，正式打印期间把识别到的图框外边框临时移到“LA-临时不打印层”；打印完成、失败或取消后立即恢复。");
+            "勾选后，正式打印把内容四边各裁 1mm，外框线不再输出；纸张、比例和留白不变。");
 
         _generatePrintLog.Text = "生成打印日志";
         _generatePrintLog.AutoSize = true;

--- a/src/Common/PlotWindowInset.cs
+++ b/src/Common/PlotWindowInset.cs
@@ -1,0 +1,150 @@
+using System;
+#if AUTOCAD
+using Autodesk.AutoCAD.DatabaseServices;
+#else
+using ZwSoft.ZwCAD.DatabaseServices;
+#endif
+
+namespace ZwcadBatchPlot;
+
+/// <summary>
+/// 将已确定的 DCS 打印窗口按纸面毫米四边内退。
+/// 调用方必须先按原窗口完成选纸、旋转、留白和比例，再决定是否内退；
+/// 内退不得回头参与比例或留白计算。
+/// </summary>
+internal static class PlotWindowInset
+{
+    /// <summary>不打印外边框时，打印内容四边各裁掉的纸面毫米。</summary>
+    internal const double PaperInsetMm = 1.0;
+
+    /// <summary>内退后纸面短边不足该值则放弃内退，避免窗口退化。</summary>
+    internal const double MinimumRemainingShortSideMm = 2.0;
+
+    /// <summary>
+    /// 按当前打印策略计算原窗口对应的 mm/图面单位。
+    /// 必须与 <c>ConfigurePlotScale</c> 使用同一套窗口和纸张，不能传入内退后的窗口。
+    /// </summary>
+    /// <param name="window">原 DCS 打印窗口。</param>
+    /// <param name="paperWidthMm">当前介质宽度（毫米）。</param>
+    /// <param name="paperHeightMm">当前介质高度（毫米）。</param>
+    /// <param name="job">打印任务，用于读取留白与原图幅。</param>
+    /// <returns>毫米/图面单位；无法计算时为 0。</returns>
+    internal static double ResolveMillimetersPerDrawingUnit(
+        Extents2d window,
+        double paperWidthMm,
+        double paperHeightMm,
+        PlotJob job)
+    {
+        return ResolveMillimetersPerDrawingUnit(
+            Math.Abs(window.MaxPoint.X - window.MinPoint.X),
+            Math.Abs(window.MaxPoint.Y - window.MinPoint.Y),
+            paperWidthMm,
+            paperHeightMm,
+            job);
+    }
+
+    /// <summary>
+    /// 按当前打印策略计算原窗口对应的 mm/图面单位。
+    /// </summary>
+    /// <param name="windowWidth">原窗口宽度（图面单位）。</param>
+    /// <param name="windowHeight">原窗口高度（图面单位）。</param>
+    /// <param name="paperWidthMm">当前介质宽度（毫米）。</param>
+    /// <param name="paperHeightMm">当前介质高度（毫米）。</param>
+    /// <param name="job">打印任务，用于读取留白与原图幅。</param>
+    /// <returns>毫米/图面单位；无法计算时为 0。</returns>
+    internal static double ResolveMillimetersPerDrawingUnit(
+        double windowWidth,
+        double windowHeight,
+        double paperWidthMm,
+        double paperHeightMm,
+        PlotJob job)
+    {
+        if (windowWidth <= 1e-12 || windowHeight <= 1e-12)
+        {
+            return 0;
+        }
+
+        if (!job.LeavePaperMargin)
+        {
+            var paperLong = Math.Max(paperWidthMm, paperHeightMm);
+            var paperShort = Math.Min(paperWidthMm, paperHeightMm);
+            var windowLong = Math.Max(windowWidth, windowHeight);
+            var windowShort = Math.Min(windowWidth, windowHeight);
+            if (paperShort <= 1e-12 || windowShort <= 1e-12)
+            {
+                return 0;
+            }
+
+            return Math.Min(paperLong / windowLong, paperShort / windowShort);
+        }
+
+        if (job.PaperMarginMm > 0d)
+        {
+            var originalShortMm = Math.Min(job.PaperWidthMm, job.PaperHeightMm);
+            var windowShortSide = Math.Min(windowWidth, windowHeight);
+            if (originalShortMm <= 1e-12 || windowShortSide <= 1e-12)
+            {
+                return 0;
+            }
+
+            return originalShortMm / windowShortSide;
+        }
+
+        var marginMm = Math.Abs(job.PaperMarginMm) > 0d ? Math.Abs(job.PaperMarginMm) : 1d;
+        var paperShortSide = Math.Min(paperWidthMm, paperHeightMm);
+        var usableShortSide = paperShortSide - marginMm * 2d;
+        var windowShortForMargin = Math.Min(windowWidth, windowHeight);
+        if (usableShortSide <= 1e-12 || windowShortForMargin <= 1e-12)
+        {
+            return 0;
+        }
+
+        return usableShortSide / windowShortForMargin;
+    }
+
+    /// <summary>
+    /// 将 DCS 窗口四边各内退指定纸面毫米。窗口过小时返回 <see langword="false"/> 并保留原窗口。
+    /// </summary>
+    /// <param name="window">原 DCS 打印窗口。</param>
+    /// <param name="millimetersPerDrawingUnit">已按原窗口算出的 mm/图面单位。</param>
+    /// <param name="insetPaperMm">每边内退的纸面毫米。</param>
+    /// <param name="insetWindow">内退后的窗口；失败时等于原窗口。</param>
+    /// <returns>是否成功内退。</returns>
+    internal static bool TryInsetByPaperMillimeters(
+        Extents2d window,
+        double millimetersPerDrawingUnit,
+        double insetPaperMm,
+        out Extents2d insetWindow)
+    {
+        insetWindow = window;
+        if (millimetersPerDrawingUnit <= 1e-12 || insetPaperMm <= 0)
+        {
+            return false;
+        }
+
+        var drawingInset = insetPaperMm / millimetersPerDrawingUnit;
+        var minX = Math.Min(window.MinPoint.X, window.MaxPoint.X);
+        var minY = Math.Min(window.MinPoint.Y, window.MaxPoint.Y);
+        var maxX = Math.Max(window.MinPoint.X, window.MaxPoint.X);
+        var maxY = Math.Max(window.MinPoint.Y, window.MaxPoint.Y);
+        var width = maxX - minX;
+        var height = maxY - minY;
+        if (width <= drawingInset * 2d || height <= drawingInset * 2d)
+        {
+            return false;
+        }
+
+        var remainingShortMm = Math.Min(width, height) * millimetersPerDrawingUnit - insetPaperMm * 2d;
+        if (remainingShortMm < MinimumRemainingShortSideMm)
+        {
+            return false;
+        }
+
+        insetWindow = new Extents2d(
+            minX + drawingInset,
+            minY + drawingInset,
+            maxX - drawingInset,
+            maxY - drawingInset);
+        return true;
+    }
+}

--- a/src/Common/TemporaryFramePlotLayer.cs
+++ b/src/Common/TemporaryFramePlotLayer.cs
@@ -13,9 +13,8 @@ using ZwSoft.ZwCAD.DatabaseServices;
 namespace ZwcadBatchPlot;
 
 /// <summary>
-/// 正式打印事务内的图框外边界临时移层逻辑。
-/// 调用方必须让所在事务在绘图引擎结束后回滚而不是提交；这样成功、失败和取消都会由 CAD 事务原子恢复，
-/// 不留下实体图层变化、临时图层或“图纸已修改”状态。
+/// 已停用：原先在正式打印事务内把图框外边界临时移到不打印层。
+/// “不打印图框的外边框”改为按纸面 1mm 内退打印窗口，见 <see cref="PlotWindowInset"/>。
 /// </summary>
 internal static class TemporaryFramePlotLayer
 {

--- a/src/ZWCAD/PlotterService.cs
+++ b/src/ZWCAD/PlotterService.cs
@@ -431,8 +431,6 @@ public static class PlotterService
         try
         {
             using var tr = db.TransactionManager.StartTransaction();
-            var frameLayerApplied = settings.HideFrameBoundaryWhenPlotting
-                && TemporaryFramePlotLayer.Apply(tr, db, job);
             var layout = FindLayoutForJob(tr, db, job);
             using var plotSettings = new PlotSettings(layout.ModelType);
             plotSettings.CopyFrom(layout);
@@ -475,9 +473,13 @@ public static class PlotterService
 
             validator.SetPlotWindowArea(plotSettings, plotWindow);
             validator.SetPlotType(plotSettings, ZwSoft.ZwCAD.DatabaseServices.PlotType.Window);
-            ConfigurePlotScale(validator, plotSettings, plotWindow, job);
+            ConfigurePlotScale(validator, plotSettings, plotWindow, job, settings.HideFrameBoundaryWhenPlotting);
             validator.SetPlotCentered(plotSettings, true);
             validator.SetPlotRotation(plotSettings, DetectRotation(media, job, plotWindow, deviceName));
+            if (settings.HideFrameBoundaryWhenPlotting)
+            {
+                TryApplyHiddenFrameWindow(validator, plotSettings, plotWindow, job);
+            }
 
             var plotInfo = new PlotInfo
             {
@@ -492,12 +494,7 @@ public static class PlotterService
 
             PrepareOutputFile(job.OutputPath);
             RunPlot(plotInfo, documentName, job.OutputPath, job.DrawingNumber);
-
-            // 临时移层与绘图处在同一事务；绘图结束后不提交即可原子恢复实体和临时图层。
-            if (!frameLayerApplied)
-            {
-                tr.Commit();
-            }
+            tr.Commit();
             WaitForPlotIdle();
             ValidatePlotOutput(job.OutputPath);
         }
@@ -536,11 +533,12 @@ public static class PlotterService
         PlotSettingsValidator validator,
         PlotSettings plotSettings,
         Extents2d window,
-        PlotJob job)
+        PlotJob job,
+        bool hideOuterFrame = false)
     {
         if (!job.LeavePaperMargin)
         {
-            if (job.UseExactWindowScale)
+            if (job.UseExactWindowScale || hideOuterFrame)
             {
                 SetExactWindowScale(validator, plotSettings, window);
                 return;
@@ -605,6 +603,42 @@ public static class PlotterService
         var scale = Math.Min(paperLong / windowLong, paperShort / windowShort);
         validator.SetUseStandardScale(plotSettings, false);
         validator.SetCustomPrintScale(plotSettings, new CustomScale(scale, 1d));
+    }
+
+    /// <summary>
+    /// 在比例已按原窗口写入后，把打印窗口四边各内退 1mm 纸面。
+    /// 选纸、旋转和留白仍使用 <paramref name="originalWindow"/>。
+    /// </summary>
+    private static void TryApplyHiddenFrameWindow(
+        PlotSettingsValidator validator,
+        PlotSettings plotSettings,
+        Extents2d originalWindow,
+        PlotJob job)
+    {
+        var paper = plotSettings.PlotPaperSize;
+        var paperWidthMm = job.EffectivePaperWidthMm > 0 ? job.EffectivePaperWidthMm : job.PaperWidthMm;
+        var paperHeightMm = job.EffectivePaperHeightMm > 0 ? job.EffectivePaperHeightMm : job.PaperHeightMm;
+        if (paperWidthMm <= 1e-9 || paperHeightMm <= 1e-9)
+        {
+            paperWidthMm = paper.X;
+            paperHeightMm = paper.Y;
+        }
+
+        var millimetersPerDrawingUnit = PlotWindowInset.ResolveMillimetersPerDrawingUnit(
+            originalWindow,
+            paperWidthMm,
+            paperHeightMm,
+            job);
+        if (!PlotWindowInset.TryInsetByPaperMillimeters(
+                originalWindow,
+                millimetersPerDrawingUnit,
+                PlotWindowInset.PaperInsetMm,
+                out var insetWindow))
+        {
+            return;
+        }
+
+        validator.SetPlotWindowArea(plotSettings, insetWindow);
     }
 
     private static Extents2d GetPlotWindow(PlotJob job, Document? plotDocument)
@@ -783,8 +817,6 @@ public static class PlotterService
         {
             using var tr = db.TransactionManager.StartTransaction();
             var singleSettings = AppSettingsStore.Load();
-            var frameLayerApplied = singleSettings.HideFrameBoundaryWhenPlotting
-                && TemporaryFramePlotLayer.Apply(tr, db, job);
             var layout = FindLayoutForJob(tr, db, job);
             using var plotSettings = new PlotSettings(layout.ModelType);
             plotSettings.CopyFrom(layout);
@@ -824,9 +856,13 @@ public static class PlotterService
 
             validator.SetPlotWindowArea(plotSettings, plotWindow);
             validator.SetPlotType(plotSettings, ZwSoft.ZwCAD.DatabaseServices.PlotType.Window);
-            ConfigurePlotScale(validator, plotSettings, plotWindow, job);
+            ConfigurePlotScale(validator, plotSettings, plotWindow, job, singleSettings.HideFrameBoundaryWhenPlotting);
             validator.SetPlotCentered(plotSettings, true);
             validator.SetPlotRotation(plotSettings, DetectRotation(media, job, plotWindow, deviceName));
+            if (singleSettings.HideFrameBoundaryWhenPlotting)
+            {
+                TryApplyHiddenFrameWindow(validator, plotSettings, plotWindow, job);
+            }
 
             var plotInfo = new PlotInfo
             {
@@ -839,13 +875,7 @@ public static class PlotterService
             }.Validate(plotInfo);
 
             RunPreview(plotInfo, documentName);
-
-            // 预览必须和正式输出使用同一套外框可打印状态；应用临时移层后不提交事务，
-            // 预览关闭、失败或取消时均由 CAD 原子回滚，避免修改用户图纸。
-            if (!frameLayerApplied)
-            {
-                tr.Commit();
-            }
+            tr.Commit();
             WaitForPlotIdle();
         }
         finally


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
勾选「不打印图框的外边框」后，不再把外框实体临时移到不打印层，改为在绘图仪写入窗口时把 **已经确定的打印内容** 四边各裁 1mm（纸面毫米）。

## 行为

- 选纸、旋转、留白、比例全部仍按 **原 DCS 窗口** 计算
- 内退只替换 `SetPlotWindowArea`，不改 `PaperMarginMm` / 扩纸
- 勾选去外框时，无留白的默认 `ScaleToFit` 改为按原窗口算出的自定义比例，避免裁小后的窗口被重新铺满纸面
- 窗口过小无法内退时保持原窗口，打印不报错
- 不再改 DWG，打印事务正常提交

## 涉及文件

- 新增 `PlotWindowInset.cs`：1mm 换算与四边内退
- AutoCAD / ZWCAD `PlotterService`：打印和预览接入
- 设置项提示文案更新
- `TemporaryFramePlotLayer` 暂留但已停用

## 建议验收

1. 只去外框：图签位置和比例不变，最外一圈线消失，四周约 1mm 空白
2. 只留白：与改前一致
3. 正/负留白 + 去外框：留白量不变，外框被裁掉
4. 四线段外框、预览、单张打印、PDF/PNG
5. 勾选后 DWG 不应变成「已修改」
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da5134a2-5540-4973-bede-6a94817ebb6f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da5134a2-5540-4973-bede-6a94817ebb6f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

